### PR TITLE
#85 Post adapter refactoring

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -59,6 +59,9 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+    dataBinding {
+        enabled = true
+    }
     lintOptions {
         lintConfig file("app/lint.xml")
     }

--- a/app/src/main/java/com/example/desiregallery/adapters/PostAdapter.kt
+++ b/app/src/main/java/com/example/desiregallery/adapters/PostAdapter.kt
@@ -1,120 +1,32 @@
 package com.example.desiregallery.adapters
 
-import android.content.Context
-import android.graphics.drawable.BitmapDrawable
-import androidx.recyclerview.widget.RecyclerView
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
-import android.widget.*
-import com.example.desiregallery.ui.dialogs.ImageRateDialog
+import androidx.databinding.DataBindingUtil
+import androidx.recyclerview.widget.RecyclerView
 import com.example.desiregallery.R
+import com.example.desiregallery.databinding.ItemPostBinding
 import com.example.desiregallery.models.Post
 import com.example.desiregallery.presenters.PostPresenter
-import com.example.desiregallery.ui.views.PostView
-import com.squareup.picasso.Callback
-import com.squareup.picasso.Picasso
-import de.hdodenhof.circleimageview.CircleImageView
-import kotlinx.android.synthetic.main.item_post.view.*
+import com.example.desiregallery.ui.views.PostViewHolder
 
 class PostAdapter(
-    private val items: List<Post>,
-    private val context: Context
-) : RecyclerView.Adapter<PostAdapter.ViewHolder>() {
+    private val items: List<Post>
+) : RecyclerView.Adapter<PostViewHolder>() {
 
     override fun getItemCount() = items.size
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
-        val view = LayoutInflater.from(context).inflate(R.layout.item_post, parent, false)
-        return ViewHolder(view)
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PostViewHolder {
+        val inflater = LayoutInflater.from(parent.context)
+        val bind =
+            DataBindingUtil.inflate<ItemPostBinding>(inflater, R.layout.item_post, parent, false)
+        return PostViewHolder(bind)
     }
 
-    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+    override fun onBindViewHolder(holder: PostViewHolder, position: Int) {
         val item = items[position]
         val presenter = PostPresenter(holder, item)
-        holder.bind(context, presenter)
+        holder.bind(holder.itemView.context, presenter)
     }
 
-    class ViewHolder(view: View) : RecyclerView.ViewHolder(view), PostView {
-        private val imageView: ImageView = view.item_post_image
-        private val ratingTextView: TextView = view.item_post_rating
-        private val commentView: ImageView = view.item_post_comment
-        private val progressBar: ProgressBar = view.item_progress
-        private val authorTextView: TextView = view.item_author_text
-        private val authorImage: CircleImageView = view.item_author_image
-
-        private lateinit var rateDialog: ImageRateDialog
-
-        private lateinit var context: Context
-        private lateinit var presenter: PostPresenter
-
-        private val handleRate = fun(rate: Float) {
-            rateDialog.hide()
-            presenter.updateRating(rate)
-        }
-
-        override fun updateRating(rating: Float) {
-            ratingTextView.text = context.getString(R.string.item_post_rating_format, rating)
-        }
-
-        override fun updateImage(imageUrl: String) {
-            Picasso.with(context)
-                .load(imageUrl)
-                .error(R.drawable.image_error)
-                .into(imageView, object: Callback {
-                    override fun onSuccess() {
-                        progressBar.visibility = View.GONE
-                    }
-
-                    override fun onError() {
-                        progressBar.visibility = View.GONE
-                    }
-                })
-        }
-
-        override fun updateAuthorName(name: String) {
-            authorTextView.text = name
-        }
-
-        override fun updateAuthorPhoto(imageUrl: String) {
-            if (imageUrl.isEmpty()) {
-                Picasso.with(context)
-                    .load(R.drawable.material)
-                    .error(R.drawable.image_error)
-                    .into(authorImage)
-            }
-            else {
-                Picasso.with(context)
-                    .load(imageUrl)
-                    .error(R.drawable.image_error)
-                    .placeholder(R.drawable.material)
-                    .into(authorImage)
-            }
-        }
-
-        fun bind(context: Context, presenter: PostPresenter) {
-            this.context = context
-            this.presenter = presenter
-
-            presenter.setImageView()
-            presenter.setRating()
-            presenter.setAuthorName()
-            presenter.setAuthorPhoto()
-            initListeners()
-        }
-
-        private fun initListeners() {
-            imageView.setOnClickListener {
-                val bmpImage = (imageView.drawable as BitmapDrawable).bitmap
-                presenter.goToImageFullScreen(context, bmpImage)
-            }
-            ratingTextView.setOnClickListener{
-                rateDialog = ImageRateDialog(context, handleRate)
-                rateDialog.show()
-            }
-            commentView.setOnClickListener{
-                presenter.goToCommentActivity(context)
-            }
-        }
-    }
 }

--- a/app/src/main/java/com/example/desiregallery/ui/fragments/FeedFragment.kt
+++ b/app/src/main/java/com/example/desiregallery/ui/fragments/FeedFragment.kt
@@ -4,12 +4,12 @@ import android.app.Activity
 import android.content.Intent
 import android.graphics.BitmapFactory
 import android.os.Bundle
-import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProviders
-import androidx.recyclerview.widget.LinearLayoutManager
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.lifecycle.Observer
+import androidx.lifecycle.ViewModelProvider
+import androidx.recyclerview.widget.LinearLayoutManager
 import com.example.desiregallery.R
 import com.example.desiregallery.adapters.PostAdapter
 import com.example.desiregallery.models.Post
@@ -26,7 +26,11 @@ class FeedFragment : androidx.fragment.app.Fragment() {
         model.addPost(post)
     }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
         val view = inflater.inflate(R.layout.fragment_feed, container, false)
         view.feed_fab.setOnClickListener { CropImage.activity().start(context!!, this) }
 
@@ -45,13 +49,15 @@ class FeedFragment : androidx.fragment.app.Fragment() {
     }
 
     private fun initModel() {
-        model = ViewModelProviders.of(this).get(PostListViewModel::class.java)
-        model.getPosts().observe(this, Observer<List<Post>>{ posts ->
-            post_list.setItemViewCacheSize(20)
-            post_list.isDrawingCacheEnabled = true
-            post_list.drawingCacheQuality = View.DRAWING_CACHE_QUALITY_HIGH
-            post_list.layoutManager = LinearLayoutManager(activity)
-            post_list.adapter = PostAdapter(posts, activity!!)
+        model = ViewModelProvider(this).get(PostListViewModel::class.java)
+        model.getPosts().observe(this, Observer<List<Post>> { posts ->
+            post_list.apply {
+                setItemViewCacheSize(20)
+                layoutManager = LinearLayoutManager(context)
+                adapter = PostAdapter(posts)
+                isDrawingCacheEnabled = true
+                drawingCacheQuality = View.DRAWING_CACHE_QUALITY_HIGH
+            }
         })
     }
 }

--- a/app/src/main/java/com/example/desiregallery/ui/views/PostViewHolder.kt
+++ b/app/src/main/java/com/example/desiregallery/ui/views/PostViewHolder.kt
@@ -1,0 +1,90 @@
+package com.example.desiregallery.ui.views
+
+import android.content.Context
+import android.graphics.drawable.BitmapDrawable
+import android.view.View
+import androidx.recyclerview.widget.RecyclerView
+import com.example.desiregallery.R
+import com.example.desiregallery.databinding.ItemPostBinding
+import com.example.desiregallery.presenters.PostPresenter
+import com.example.desiregallery.ui.dialogs.ImageRateDialog
+import com.squareup.picasso.Callback
+import com.squareup.picasso.Picasso
+
+class PostViewHolder(
+    private val bind: ItemPostBinding
+) : RecyclerView.ViewHolder(bind.root), PostView {
+
+    private lateinit var rateDialog: ImageRateDialog
+    private lateinit var presenter: PostPresenter
+
+    private val handleRate = fun(rate: Float) {
+        rateDialog.hide()
+        presenter.updateRating(rate)
+    }
+
+    override fun updateRating(rating: Float) {
+        bind.itemPostRating.text = bind.itemPostRating
+            .context
+            .getString(R.string.item_post_rating_format, rating)
+    }
+
+    override fun updateImage(imageUrl: String) {
+        Picasso.with(bind.itemPostImage.context)
+            .load(imageUrl)
+            .error(R.drawable.image_error)
+            .into(bind.itemPostImage, object : Callback {
+                override fun onSuccess() {
+                    bind.itemProgress.visibility = View.GONE
+                }
+
+                override fun onError() {
+                    bind.itemProgress.visibility = View.GONE
+                }
+            })
+    }
+
+    override fun updateAuthorName(name: String) {
+        bind.itemAuthorText.text = name
+    }
+
+    override fun updateAuthorPhoto(imageUrl: String) {
+        if (imageUrl.isEmpty()) {
+            Picasso.with(bind.itemAuthorImage.context)
+                .load(R.drawable.material)
+                .error(R.drawable.image_error)
+                .into(bind.itemAuthorImage)
+        } else {
+            Picasso.with(bind.itemAuthorImage.context)
+                .load(imageUrl)
+                .error(R.drawable.image_error)
+                .placeholder(R.drawable.material)
+                .into(bind.itemAuthorImage)
+
+        }
+    }
+
+    fun bind(context: Context, presenter: PostPresenter) {
+        this.presenter = presenter
+
+        presenter.setImageView()
+        presenter.setRating()
+        presenter.setAuthorName()
+        presenter.setAuthorPhoto()
+        initListeners(context)
+    }
+
+    private fun initListeners(context: Context) {
+        bind.itemPostImage.setOnClickListener {
+            val bmpImage = (bind.itemPostImage.drawable as BitmapDrawable).bitmap
+            presenter.goToImageFullScreen(bind.itemPostImage.context, bmpImage)
+        }
+        bind.itemPostRating.setOnClickListener {
+            rateDialog = ImageRateDialog(bind.itemPostRating.context, handleRate)
+            rateDialog.show()
+        }
+        bind.itemPostComment.setOnClickListener {
+            presenter.goToCommentActivity(context)
+        }
+    }
+}

--- a/app/src/main/res/layout/item_post.xml
+++ b/app/src/main/res/layout/item_post.xml
@@ -1,27 +1,36 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
-        xmlns:tools="http://schemas.android.com/tools"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="post"
+            type="com.example.desiregallery.models.Post" />
+
+    </data>
+
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical">
 
-    <LinearLayout
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:padding="@dimen/item_author_container_padding"
             android:orientation="horizontal">
 
-        <de.hdodenhof.circleimageview.CircleImageView
+            <de.hdodenhof.circleimageview.CircleImageView
                 android:id="@+id/item_author_image"
                 android:layout_width="40dp"
                 android:layout_height="40dp"
                 android:layout_marginLeft="@dimen/item_author_image_margin_left"
                 android:layout_marginStart="@dimen/item_author_image_margin_left"
-                tools:src="@drawable/material"/>
+                tools:src="@drawable/material" />
 
-        <TextView
+            <TextView
                 android:id="@+id/item_author_text"
                 android:layout_width="0dp"
                 android:layout_height="match_parent"
@@ -30,35 +39,35 @@
                 android:layout_marginStart="@dimen/item_author_text_margin_left"
                 android:layout_marginLeft="@dimen/item_author_text_margin_left"
                 android:gravity="center_vertical"
-                tools:text="Nickname"/>
-    </LinearLayout>
+                tools:text="Nickname" />
+        </LinearLayout>
 
-    <RelativeLayout
+        <RelativeLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content">
 
-        <ImageView
+            <ImageView
                 android:id="@+id/item_post_image"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:adjustViewBounds="true"/>
+                android:adjustViewBounds="true" />
 
-        <ProgressBar
+            <ProgressBar
                 android:id="@+id/item_progress"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_centerInParent="true"
                 android:visibility="visible"
-                style="?android:attr/progressBarStyleLarge"/>
+                style="?android:attr/progressBarStyleLarge" />
 
-    </RelativeLayout>
+        </RelativeLayout>
 
-    <RelativeLayout
+        <RelativeLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:padding="@dimen/item_status_padding">
 
-        <TextView
+            <TextView
                 android:id="@+id/item_post_rating"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -68,9 +77,9 @@
                 android:drawableStart="@drawable/ic_grade_gold_32dp"
                 android:textColor="@color/colorOnBackground"
                 android:textSize="@dimen/item_rating_font_size"
-                android:text="@string/item_post_rating_placeholder"/>
+                android:text="@string/item_post_rating_placeholder" />
 
-        <ImageView
+            <ImageView
                 android:id="@+id/item_post_comment"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -78,13 +87,14 @@
                 android:layout_marginStart="8dp"
                 android:layout_alignParentLeft="true"
                 android:layout_alignParentStart="true"
-                app:srcCompat="@drawable/ic_comment_colorsecondary_32dp"/>
+                app:srcCompat="@drawable/ic_comment_colorsecondary_32dp" />
 
-    </RelativeLayout>
+        </RelativeLayout>
 
-    <View
+        <View
             android:layout_width="match_parent"
             android:layout_height="1dp"
-            android:background="@color/colorSecondary"/>
+            android:background="@color/colorSecondary" />
 
-</LinearLayout>
+    </LinearLayout>
+</layout>


### PR DESCRIPTION
remove the view holder from the PostAdapter and set it a single class. add databinding to reduce the boilerplate. remove the context from the holder, and use the views components to achieve the same result.